### PR TITLE
Add ability to specify browser binary path with -B

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ You can alternatively specify the `--prompt-password` option instead of using `-
 
 JMU OpenConnect defaults to using firefox, but you can easily change which browser you're using by specifying `--browser`, which accepts `firefox`, `chrome`, or `edge`.
 
+The first time that you launch JMU OpenConnect, it may take a little longer than normal, as selenium has to download and cache your webdriver.
+
 ```console
 $ jmu-openconnect --browser chrome
 ```
@@ -48,7 +50,7 @@ $ jmu-openconnect --browser chrome
 To see all of the available options, run `jmu-openconnect --help`.
 
 ## Dependencies
-This script just requires openconnect, [selenium](https://pypi.org/project/selenium/), and a webdriver. On my machine, it seems that the webdrivers are automatically installed if you have Firefox or Chromium installed, so you probably don't need to worry about this. If you are having problems, check the [Selenium Python Documentation](https://selenium-python.readthedocs.io/installation.html#drivers0).
+This script just requires openconnect and [selenium](https://pypi.org/project/selenium/). If you are having problems, check the [Selenium Python Documentation](https://selenium-python.readthedocs.io/installation.html#drivers0).
 
 ## Why is this all in one script?
 I heavily considered splitting this up into multiple files, but I really wanted to preserve the ability to just have this script up on a website somewhere where people could just download this script, install selenium, and run it with Python. This may change in the future but this is what I've gone with for now.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import getpass
+import json
 import logging
 import os
 import shutil
@@ -9,9 +10,15 @@ import subprocess
 import sys
 import time
 from enum import Enum
+from typing import Optional
+from urllib import request
 
 from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import (
+	NoSuchElementException,
+	TimeoutException,
+	WebDriverException,
+)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC  # noqa: N812
 from selenium.webdriver.support.wait import WebDriverWait
@@ -20,9 +27,9 @@ from selenium.webdriver.support.wait import WebDriverWait
 class Browser(Enum):
 	"""Specify a browser to use"""
 
-	FIREFOX = webdriver.Firefox
-	CHROME = webdriver.Chrome
-	EDGE = webdriver.Edge
+	FIREFOX = {'driver': webdriver.Firefox, 'options': webdriver.FirefoxOptions}
+	CHROME = {'driver': webdriver.Chrome, 'options': webdriver.ChromeOptions}
+	EDGE = {'driver': webdriver.Edge, 'options': webdriver.EdgeOptions}
 
 
 class MissingDSIDError(Exception):
@@ -61,10 +68,77 @@ class MissingOpenConnectError(Exception):
 		super().__init__(msg, *args, **kwargs)
 
 
+def fetch_latest_browser_version(browser: Browser) -> str:
+	"""Fetches the latest firefox/chromium version from mozilla's/google's API.
+
+	Args:
+		browser (Browser): The browser to fetch the version number
+
+	Returns:
+		str: The version number as a string. Empty string if something went wrong
+	"""
+	if browser == Browser.FIREFOX:
+		firefox_ver = request.urlopen(
+			'https://product-details.mozilla.org/1.0/firefox_history_major_releases.json'
+		)
+		if firefox_ver.getcode() == 200:
+			try:
+				# load firefox version info
+				firefox_data: dict[str, str] = json.loads(firefox_ver.read())
+				# sort firefox version info by most recent release first
+				ver = sorted(
+					firefox_data.keys(), key=lambda ver: int(ver.split('.')[0])
+				)
+				# return the greatest version number (last in the list)
+				return ver[-1]
+			except json.JSONDecodeError:
+				return ''
+		else:
+			return ''
+
+	elif browser == Browser.CHROME:
+		chrome_ver = request.urlopen(
+			'https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions'
+		)
+		if chrome_ver.getcode() == 200:
+			try:
+				# load chrome version info
+				chrome_data: dict[str, list[dict[str, str]]] = json.loads(
+					chrome_ver.read()
+				)
+				# return the greatest version number (first in the list)
+				return chrome_data['versions'][0]['version']
+			except json.JSONDecodeError:
+				return ''
+		else:
+			return ''
+	elif browser == Browser.EDGE:
+		edge_ver = request.urlopen(
+			'https://edgeupdates.microsoft.com/api/products/?view=enterprise'
+		)
+		if edge_ver.getcode() == 200:
+			try:
+				# load edge version info
+				edge_data: list[dict] = json.loads(edge_ver.read())
+				# find the latest stable release
+				stable_rel = next(
+					item for item in edge_data if item['Product'] == 'Stable'
+				)
+				# return the greatest version number (first in the list)
+				return stable_rel['Releases'][0]['ProductVersion']
+			except json.JSONDecodeError:
+				return ''
+		else:
+			return ''
+	else:
+		return ''
+
+
 def get_dsid_cookie(
 	username: str = '',
 	password: str = '',
 	browser: Browser = Browser.FIREFOX,
+	browser_binary: Optional[str] = None,
 	webdriver_timeout: int = 300,
 	debug_auth_error: bool = False,
 ) -> str:
@@ -76,6 +150,7 @@ def get_dsid_cookie(
 		username (str, optional): Automatically type in a username.
 		password (str, optional): Automatically type in a password.
 		browser (Browser, optional): Specify a browser to use. Defaults to FIREFOX.
+		browser_binary: (Optional[str], optional): Specify a path to your browser's binary. Defaults to None.
 		webdriver_timeout (int, optional): The amount of time before the webdriver times out. Defaults to 300.
 		debug_auth_error (bool, optional): Whether or not to pause after authentication for debugging. Defaults to False.
 
@@ -88,10 +163,30 @@ def get_dsid_cookie(
 	"""
 	logging.info("Fetching user's DSID cookie")
 
-	logging.debug('Launching browser')
-	# dynamically select the browser to use
-	driver = browser.value()
+	# create browser specific options
+	options = browser.value['options']()
 
+	# set the path to the browser's binary if set
+	if browser_binary is not None:
+		logging.debug(f'Setting browser binary path to `{browser_binary}`')
+		options.binary_location = browser_binary
+
+	# dynamically select the browser to use
+	logging.debug('Launching browser')
+	try:
+		driver = browser.value['driver'](options=options)
+	except WebDriverException as e:
+		# the browser version probably wasn't detected correctly, try to fetch it from the web
+		logging.warning('Browser version incorrectly detected')
+		logging.debug(e, exc_info=True)
+		logging.info(f'Trying to retreieve latest browser version for {browser}')
+		options.browser_version = fetch_latest_browser_version(browser)
+		logging.info(f'Latest browser version: {options.browser_version!r}')
+		logging.info('Relaunching browser')
+		# retry launching
+		driver = browser.value['driver'](options=options)
+
+	# driver has been successfully started
 	logging.debug('Launching vpn.jmu.edu for authentication')
 	driver.get('https://vpn.jmu.edu')
 
@@ -226,6 +321,12 @@ def main():
 	)
 
 	parser.add_argument(
+		'--browser-binary',
+		'-B',
+		help="Specify a path to your browser's binary. Useful if you use a derivative of a supported browser, like WaterFox.",
+	)
+
+	parser.add_argument(
 		'--username',
 		'-u',
 		default='',
@@ -283,6 +384,7 @@ def main():
 			username=args.username,
 			password=password,
 			browser=browser,
+			browser_binary=args.browser_binary,
 			webdriver_timeout=args.timeout,
 			debug_auth_error=args.debug_auth_error,
 		)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jmu-openconnect"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wrapper script around openconnect forJMU VPN authentication on Linux."
 authors = ["TabulateJarl8 <tabulatejarl8@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This PR adds the ability to specify the browser binary path with `--browser-binary` or `-B`. In the case that the browser version is incorrectly detected (I ran into this problem when selenium was trying to find the geckodriver version for Waterfox, which uses a different versioning scheme than Firefox), the program attempts to retrieve the latest version of Firefox/Chrome/Edge from the respective API, and passes that to selenium in an attempt to fix the issue.

Closes #1 